### PR TITLE
Amend code to make it cross platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /.gitignore
 /benchmarks/Faster.Map.Concurrent.Benchmark/bin/Debug/net7.0
 /benchmarks/Faster.Map.Concurrent.Benchmark/bin/Release/net7.0
+/src/obj


### PR DESCRIPTION
Replaced SSE2 method calls CompareEqual and MoveMask with the platform independent alternatives Vector128.Equal and Vector128.ExtractMostSignificantBits